### PR TITLE
#161966900 Upgrade Authors Haven Django app from Django 1…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-Django==1.10
+coverage==4.5.2
+Django==2.1.3
 django-cors-middleware==1.2.0
 django-extensions==1.7.1
 djangorestframework==3.4.4
 PyJWT==1.4.2
+pytz==2018.7
 six==1.10.0


### PR DESCRIPTION
#### What does this PR do?
Upgrade Authors Haven Django app from Django 1.10 to Django 2.1.3

#### Description of Task to be completed?
- Uninstall Django 1.10
- Install Django 2.1.3
- Change the Django version in the requirements.txt to Django 2.1.3

#### Any background context you want to provide?
Django 2.x is the latest release of Django with the full support of the Python 3.x series.

#### What are the relevant pivotal tracker stories?
[#162036573](https://www.pivotaltracker.com/story/show/161966900)