### PR TITLE
chore(login): test user login process after they submit email and pas…

### DIFF
--- a/authors/apps/authentication/tests/login_tests.py
+++ b/authors/apps/authentication/tests/login_tests.py
@@ -1,0 +1,50 @@
+"""This module runs tests for user login process"""
+import json
+from django.test import TestCase
+from rest_framework.test import APIClient
+from rest_framework import status
+
+
+class UserTestCase(TestCase):
+    """This class contains tests for the user login process wihtout social authentication"""
+    def setUp(self):
+        """This function defines variables tobe used within the class"""
+        self.client = APIClient()
+        self.test_user = {'email' : 'remmy@test.com',
+                          'password' : 'Password123'}
+        self.test_unknown_user = {'email' : 'john@doe.com',
+                                  'password' : 'Password123'}
+        self.test_password = {'email' : 'remmy@test.com',
+                              'password' : 'passssssss'}
+    def test_login_user(self):
+        """This function tests whether a registered user can login"""
+        response = self.client.post(
+            'api/users/login',
+            data=json.dumps(self.test_user),
+            format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json.loads(response.data)["message"],
+                         "User logged in successfully")
+        self.assertNotEqual(json.loads(response.data)["token"], None)
+    def test_cannot_login_unregistered_user(self):
+        """This function tests whether an unregistered user can login"""
+        response = self.client.post(
+            'api/users/login',
+            data=json.dumps(self.test_unknown_user),
+            format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(json.loads(response.data)["message"], "User does not exist.")
+        self.assertEqual(json.loads(response.data)["token"], None)
+    def test_cannot_login_user_with_wrong_password(self):
+        """This function tests whether a registered user can login with wrong password"""
+        response = self.client.post(
+            'api/users/login',
+            data=json.dumps(self.test_password),
+            format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(json.loads(response.data)["message"],
+                         "Either the email and/or the password is wrong.")
+        self.assertEqual(json.loads(response.data)["token"], None)
+        


### PR DESCRIPTION
#### What does this PR do?
Tests the normal login process where the user inputs their email and id.
#### Description of Task to be completed?
Write failing tests before the login feature is implemented. 
#### How should this be manually tested?

- After cloning the repo, CD into it. 

- Create and start your virtual environment 

- Install dependencies. `pip3 install -r requirements.txt`

- Define the following environment variables and place them in a `.env` file in the root directory

> 

`export DATABASE_USER='postgres'
export DATABASE_PASSWORD='postgres'
export HOST='localhost'
export PORT='5432'
export DATABASE_TEST='test_db' `

>

- Add the variables into the virtual environment you just created. `source .env`

- run `python3 manage.py test`. If the tests cannot be found automatically, you'll need to add the url after the word test (  `python3 manage.py test authors.apps.authentication.tests.login_tests` )
#### Any background context you want to provide?
The user will have login into the app by providing email and password.
#### What are the relevant pivotal tracker stories?
[#161966897](https://www.pivotaltracker.com/story/show/161966897)
#### Screenshots (if appropriate)
<img width="1069" alt="screenshot 2018-12-06 at 11 54 20" src="https://user-images.githubusercontent.com/16904946/49573560-547cd580-f94f-11e8-90ae-996703179edc.png">