### PR TITLE
Change error message from account disabled to account inactive

### DIFF
--- a/authors/apps/authentication/backends.py
+++ b/authors/apps/authentication/backends.py
@@ -32,8 +32,9 @@ class JWTAuthentication(authentication.BaseAuthentication):
 
         # Check whether the user is active
         if not user.is_active:
-            raise AuthenticationFailed("Your account is disabled, please "
-                                       "visit your email to activate your account")
+            raise AuthenticationFailed("Your account is inactive. Please " +
+                                       "check your email to activate your" +
+                                       " account.")
         return (user, token)
 
     def generate_token(self, email, username):

--- a/authors/apps/authentication/tests/tests_login.py
+++ b/authors/apps/authentication/tests/tests_login.py
@@ -42,8 +42,8 @@ class UserTestCase(TestCase):
         # Test user registration
         self.assertEqual(self.resp.status_code, status.HTTP_201_CREATED)
         self.assertEqual(self.resp.data["Message"],
-                         "remmy registered successfully, please check your\
-        mail to activate your account.")
+                         "remmy registered successfully, please check your " +
+                         "mail to activate your account.")
 
         # Login response
         self.response = self.client.post(
@@ -54,8 +54,8 @@ class UserTestCase(TestCase):
         )
         self.assertEqual(self.response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertIn(
-            self.response.data["detail"], "Your account is disabled, please"
-            " visit your email to activate your account")
+            self.response.data["detail"], "Your account is inactive. Please" +
+            " check your email to activate your account.")
 
     def test_cannot_login_unregistered_user(self):
         """This function tests whether an unregistered user can login"""

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -16,8 +16,7 @@ urlpatterns = [
         PasswordResetDoneAPIView.as_view(),
         name='update_password'),
     re_path(
-        r'^user/activate/(?P<uidb64>[0-9A-Za-z_\-]+)/\
-        (?P<token>[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+))/',
+        r'^user/activate/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[a-zA-Z0-9\-_]+?\.[a-zA-Z0-9\-_]+?\.([a-zA-Z0-9\-_]+))/',
         ActivationView.as_view(),
         name='activate'),
 ]

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -91,8 +91,8 @@ class RegistrationAPIView(APIView):
             fail_silently=False)
         message = {
             'Message':
-            '{} registered successfully, please check your\
-        mail to activate your account.'.format(user['username']),
+            ('{} registered successfully, please check your '+
+            'mail to activate your account.').format(user['username']),
             "Token":
             token
         }
@@ -121,8 +121,8 @@ class ActivationView(APIView):
                     user.is_active = True
                     user.save()
                     # return redirect('home')
-                    return Response("Thank you for your email confirmation.\
-                    Now you can log into your account.")
+                    return Response("Thank you for your email confirmation." +
+                                    " Now you can log into your account.")
                 else:
                     return Response('Activation link is invalid!')
         except (TypeError, ValueError, OverflowError):

--- a/authors/apps/profiles/tests/base_test.py
+++ b/authors/apps/profiles/tests/base_test.py
@@ -56,4 +56,4 @@ class BaseTestCase(TestCase):
         self.msg = result["user"]["Message"]
 
     def test_registration(self):
-        self.assertIn('johnny registered successfully', self.msg)
+        self.assertIn('registered successfully', self.msg)

--- a/authors/apps/profiles/tests/test_userprofiles.py
+++ b/authors/apps/profiles/tests/test_userprofiles.py
@@ -12,7 +12,7 @@ class TestProfile(BaseTestCase):
         self.client.credentials(HTTP_AUTHORIZATION=self.token)
         response = self.client.get(self.all_profiles_url)
         self.assertNotEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn('Your account is disabled', str(response.data))
+        self.assertIn('Your account is inactive', str(response.data))
 
     def test_get_all_profiles_without_login2(self):
         response = self.client.get(self.profile_url)


### PR DESCRIPTION
#### What does this PR do?
- Remove bugs in develop
#### Description of Task to be completed?
- Adjust message to reflect that an account is inactive not disabled.
- Refactor tests
- Adjust url for activation
#### How should this be manually tested?
1. `git clone -b ft-users-able-report-article-161966934 https://github.com/andela/ah-infinity-stones` and `$ cd ah-infinity-stones`
2. Create and activate virtual env
- `virtualenv  -p python3 venv`
- `$ source venv/bin/activate`
3. `$ pip3 install -r requirements.txt` to install the dependencies
4. Setup environment variables. Copy all from below and paste them into the .env file. Update the values to your choice.
```export DATABASE_NAME='authors_haven'
export DATABASE_USER='postgres'
export DATABASE_PASSWORD='postgres'
export HOST='localhost'
export PORT='5432'
export DATABASE_TEST='test_authors_haven'
export EMAIL_HOST_USER='Infinites'
export EMAIL_HOST_PASSWORD='st1fflers'
export SECRET_KEY='my secret my choice'
export DATABASE_URL="postgresql://localhost/authors_haven"
```
Activate the env variables by `$source .env`.
5. Run migrations: `$ python3 manage.py migrate`
6. Run app - `$ python3 manage.py runserver`
7. Acess `http://127.0.0.1:8000/api/users/` through [Postman](https://www.getpostman.com/), provide inputs in the following format and create account.
```
{ "user": {
"username": "your name",
"email": "your@email.com",
"password": "@Password321"	
}
}
```
Check your email and activate the account. Use the registration token to access the following endpoints:




8. Run tests`python3 manage.py test authors.apps.articles.tests`
#### What are the relevant pivotal tracker stories?
[#162958995](https://www.pivotaltracker.com/story/show/162958995)

